### PR TITLE
Modify workflow for Tigris integration

### DIFF
--- a/PRODUCTION_DEPLOYMENT.md
+++ b/PRODUCTION_DEPLOYMENT.md
@@ -1,5 +1,56 @@
 # Production Deployment Guide
 
+⚠️ **DEPRECATED: This guide uses Google Cloud Storage (GCS) which has been replaced with Tigris for better performance and cost-effectiveness.**
+
+**Please use the new [Tigris Deployment Guide](./TIGRIS_DEPLOYMENT.md) instead.**
+
+---
+
+## Why We Switched to Tigris
+
+This project has migrated from Google Cloud Storage to Tigris Object Storage for the following reasons:
+
+1. **Zero Egress Costs**: Tigris eliminates data transfer fees, crucial for multi-environment access
+2. **Superior Performance**: 5-10x better performance for small objects (like SQLite WAL segments)
+3. **Optimized for Databases**: TigrisFS provides filesystem semantics optimized for database workflows
+4. **Fly.io Integration**: Native integration with better routing and performance
+5. **Strong Consistency**: Built on FoundationDB for enterprise-grade reliability
+
+## Migration Instructions
+
+If you have an existing deployment using GCS, follow these steps to migrate to Tigris:
+
+### 1. Backup Your Current Database
+
+```bash
+# Download current database from GCS
+gsutil cp gs://your-gcs-bucket/org-data/99.db ./migration-backup-$(date +%Y%m%d).db
+```
+
+### 2. Set Up Tigris
+
+Follow the [Tigris Deployment Guide](./TIGRIS_DEPLOYMENT.md) to:
+- Create a Tigris bucket on Fly.io
+- Configure the new environment variables
+- Deploy the updated application
+
+### 3. Upload Your Database to Tigris
+
+```bash
+# Upload your database to the new Tigris bucket
+aws s3 cp ./migration-backup-$(date +%Y%m%d).db s3://your-tigris-bucket/org-data/99.db \
+  --endpoint-url https://fly.storage.tigris.dev
+```
+
+### 4. Verify Migration
+
+Deploy and run your scheduler to ensure it works correctly with Tigris.
+
+## Legacy GCS Documentation
+
+<details>
+<summary>Click to expand legacy GCS deployment instructions (for reference only)</summary>
+
 This guide covers the production deployment of the OCaml Email Scheduler on Fly.io with Google Cloud Storage (GCS) integration.
 
 ## Architecture Overview
@@ -289,3 +340,5 @@ For issues with:
 - **Fly.io Platform**: Use `flyctl doctor` and Fly.io support
 - **GCS Integration**: Verify authentication and bucket permissions
 - **Database Issues**: Check SQLite file integrity and sync logs
+
+</details>

--- a/TIGRIS_DEPLOYMENT.md
+++ b/TIGRIS_DEPLOYMENT.md
@@ -1,0 +1,240 @@
+# Tigris Deployment Guide
+
+This guide covers the production deployment of the OCaml Email Scheduler on Fly.io with Tigris object storage integration.
+
+## Architecture Overview
+
+The system uses a **sqlite3_rsync + Tigris** architecture for robust, production-ready database synchronization:
+
+1. **TigrisFS Mount**: The Fly.io container mounts your Tigris bucket as a filesystem using the optimized TigrisFS FUSE driver
+2. **Database Sync**: `sqlite3_rsync` efficiently synchronizes the SQLite database between local storage and Tigris
+3. **Atomic Operations**: All database operations are atomic, ensuring data consistency
+4. **Zero Egress Costs**: Tigris provides free egress, making multi-environment access cost-effective
+
+## Prerequisites
+
+1. **Fly.io Account**: [Sign up at fly.io](https://fly.io/app/sign-up)
+2. **Tigris Account**: [Sign up at tigris.dev](https://www.tigris.dev/)
+3. **flyctl CLI**: [Install flyctl](https://fly.io/docs/hands-on/install-flyctl/)
+
+## Setup Instructions
+
+### 1. Create Tigris Storage on Fly.io
+
+Fly.io provides native Tigris integration. Create your storage bucket:
+
+```bash
+# Create a new Tigris bucket (this is the preferred method on Fly.io)
+fly storage create --name your-email-scheduler-bucket
+
+# Or create through the Tigris console if you prefer manual setup
+```
+
+The `fly storage create` command automatically:
+- Creates the bucket in Tigris
+- Sets up optimized routing from Fly.io infrastructure
+- Provides the necessary credentials as environment variables
+
+### 2. Configure Secrets
+
+Set your Tigris credentials as Fly.io secrets:
+
+```bash
+# If using fly storage create, these are set automatically
+# Otherwise, set them manually with your Tigris credentials
+flyctl secrets set AWS_ACCESS_KEY_ID="tid_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+flyctl secrets set AWS_SECRET_ACCESS_KEY="tsec_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+### 3. Update fly.toml Configuration
+
+Update your `fly.toml` with the correct bucket name:
+
+```toml
+[env]
+  BUCKET_NAME = "your-email-scheduler-bucket"  # Use your actual bucket name
+  ORG_ID = "99"
+  OCAMLLOG = "info"
+  AWS_REGION = "auto"
+  AWS_ENDPOINT_URL_S3 = "https://fly.storage.tigris.dev"
+```
+
+### 4. Deploy to Fly.io
+
+```bash
+# Deploy the application
+flyctl deploy
+
+# Create a persistent volume for local database copy
+flyctl volumes create scheduler_data --region ord --size 10
+
+# Run the scheduler
+flyctl machine run . --region ord
+```
+
+## Expected Output
+
+When the scheduler runs successfully, you'll see output like:
+
+```
+🚀 Starting Email Scheduler with Tigris Sync...
+🔐 Setting up Tigris authentication...
+Using endpoint: https://fly.storage.tigris.dev
+Bucket: your-email-scheduler-bucket
+📁 Mounting Tigris bucket: your-email-scheduler-bucket...
+✅ Tigris bucket mounted successfully
+📥 Syncing database from Tigris to local working copy...
+✅ Database synced from Tigris successfully
+🏃 Running OCaml Email Scheduler...
+✅ OCaml scheduler completed successfully
+📤 Syncing modified database back to Tigris...
+✅ Database synced back to Tigris successfully
+🎉 Email Scheduler completed successfully!
+```
+
+## Backup and Recovery
+
+### Primary Backup: Tigris Global Distribution
+
+**Tigris automatically replicates your data globally** across multiple regions, providing built-in redundancy and disaster recovery.
+
+Key advantages:
+- **Automatic multi-region replication**: Your SQLite database is automatically replicated across Tigris's global network
+- **Strong consistency**: All replicas are strongly consistent, ensuring data integrity
+- **Zero egress fees**: You can restore your database from any region without additional costs
+- **High availability**: Built on FoundationDB for enterprise-grade reliability
+
+### Manual Backup Strategy
+
+For additional protection, you can implement periodic backups:
+
+```bash
+# Manual backup script (run via cron or Fly.io scheduled machine)
+#!/bin/bash
+BACKUP_NAME="backup-$(date +%Y%m%d-%H%M%S).db"
+sqlite3 /app/data/working_copy.db ".backup /tmp/$BACKUP_NAME"
+
+# Upload to a separate backup directory in Tigris
+aws s3 cp "/tmp/$BACKUP_NAME" "s3://$BUCKET_NAME/backups/$BACKUP_NAME" \
+  --endpoint-url "$AWS_ENDPOINT_URL_S3"
+```
+
+## Monitoring and Troubleshooting
+
+### Health Checks
+
+Monitor your deployment with Fly.io logs:
+
+```bash
+# View real-time logs
+flyctl logs
+
+# Check machine status
+flyctl status
+
+# Access Tigris bucket contents
+flyctl ssh console
+ls -la /tigris/org-data/
+```
+
+### Common Issues and Solutions
+
+#### 1. Tigris Authentication Failure
+
+```
+❌ ERROR: AWS_ACCESS_KEY_ID environment variable is not set
+```
+
+**Solution:**
+```bash
+flyctl secrets set AWS_ACCESS_KEY_ID="your-tigris-access-key"
+flyctl secrets set AWS_SECRET_ACCESS_KEY="your-tigris-secret-key"
+```
+
+#### 2. TigrisFS Mount Failure
+
+```
+❌ ERROR: Failed to mount Tigris bucket
+```
+
+**Solutions:**
+- Verify bucket name is correct in `fly.toml`
+- Ensure FUSE is enabled in container (already configured in Dockerfile)
+- Check Tigris credentials are valid
+- Verify network connectivity to Tigris endpoint
+
+#### 3. Database Sync Failure
+
+```
+❌ ERROR: Failed to sync database from Tigris
+```
+
+**Solutions:**
+- Check if database file exists in Tigris bucket
+- Verify sqlite3_rsync binary is installed and executable
+- Ensure sufficient disk space in `/app/data` volume
+- Check file permissions in mounted Tigris filesystem
+
+## Performance Optimization
+
+### TigrisFS Performance
+
+The TigrisFS FUSE driver is optimized for small objects and provides:
+- **5-10x better performance** than generic S3 FUSE solutions
+- **Sub-millisecond latency** for small file operations
+- **Automatic caching** for frequently accessed files
+
+### Resource Allocation
+
+For optimal performance, ensure your `fly.toml` allocates sufficient resources:
+
+```toml
+[[vm]]
+  memory = "4gb"     # Sufficient for database operations and caching
+  cpu_kind = "performance"
+  cpus = 4           # Multiple cores for concurrent I/O operations
+```
+
+## Cost Optimization
+
+### Tigris Pricing Benefits
+
+- **Zero egress fees**: No charges for data transfer out of Tigris
+- **Global distribution included**: No additional costs for multi-region replication
+- **Pay for what you use**: Only pay for actual storage consumed
+
+### Storage Lifecycle
+
+Tigris automatically optimizes storage costs:
+- **Frequent access**: Data is cached globally for fast access
+- **Infrequent access**: Data is automatically moved to more cost-effective storage tiers
+- **No complex lifecycle rules needed**: Everything is handled automatically
+
+## Security Best Practices
+
+1. **Credential Management**:
+   - Never commit Tigris credentials to version control
+   - Use Fly.io secrets for credential storage
+   - Rotate credentials periodically
+
+2. **Bucket Security**:
+   - Limit Tigris bucket access to scheduler service account only
+   - Enable bucket-level encryption (enabled by default in Tigris)
+   - Monitor access logs through Tigris console
+
+3. **Network Security**:
+   - Use Fly.io's private networking where possible
+   - Enable TLS for all Tigris communications (default with TigrisFS)
+
+## Maintenance Tasks
+
+- **Weekly**: Review application logs for any sync errors or performance issues
+- **Monthly**: Review Tigris storage usage and costs in the Tigris console
+- **Quarterly**: Verify backup restoration procedures work correctly
+
+## Support and Monitoring
+
+- **Application Logs**: Monitor via `flyctl logs`
+- **Tigris Console**: Monitor storage usage and performance at [console.tigris.dev](https://console.tigris.dev)
+- **Fly.io Dashboard**: Monitor infrastructure and resource usage
+- **Error Handling**: The scheduler automatically retries failed operations and logs detailed error information

--- a/TIGRIS_MIGRATION_SUMMARY.md
+++ b/TIGRIS_MIGRATION_SUMMARY.md
@@ -1,0 +1,163 @@
+# Tigris Migration Summary
+
+This document summarizes the changes made to migrate from Google Cloud Storage (GCS) to Tigris object storage.
+
+## 🎯 Migration Completed
+
+Your codebase has been successfully updated to use Tigris instead of GCS. Here's what changed:
+
+## 📁 Files Modified
+
+### 1. `Dockerfile`
+- **Before**: Installed Google Cloud SDK and `gcsfuse`
+- **After**: Installs TigrisFS (optimized FUSE driver for Tigris)
+- **Change**: Mount point changed from `/gcs` to `/tigris`
+
+### 2. `entrypoint.sh`
+- **Before**: Used GCS authentication with service account JSON keyfile
+- **After**: Uses AWS S3-compatible authentication with access keys
+- **Environment Variables Changed**:
+  - `GCS_KEYFILE_JSON` → `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
+  - `GCS_BUCKET_NAME` → `BUCKET_NAME`
+  - Added: `AWS_ENDPOINT_URL_S3` and `AWS_REGION`
+
+### 3. `fly.toml`
+- **Before**: `GCS_BUCKET_NAME = "your-gcs-bucket-name"`
+- **After**: `BUCKET_NAME = "your-tigris-bucket-name"`
+- **Added**: Tigris-specific environment variables
+
+### 4. `env.example`
+- **Added**: Tigris S3-compatible credential examples
+- **Updated**: Shows the new environment variable structure
+
+## 📄 New Files Created
+
+### 1. `TIGRIS_DEPLOYMENT.md`
+- Complete deployment guide for Tigris integration
+- Fly.io-specific setup instructions
+- Performance optimization tips
+- Troubleshooting guide
+
+### 2. `migrate_gcs_to_tigris.sh`
+- Automated migration script
+- Downloads database from GCS
+- Uploads to Tigris
+- Updates configuration files
+
+### 3. `TIGRIS_MIGRATION_SUMMARY.md` (this file)
+- Summary of all changes made
+
+## 📄 Files Updated
+
+### 1. `PRODUCTION_DEPLOYMENT.md`
+- Marked as deprecated
+- Added migration instructions
+- Legacy GCS content moved to collapsible section
+- Redirects to new Tigris deployment guide
+
+## 🔧 Key Technical Changes
+
+### Authentication
+- **Before**: Google Cloud service account JSON keyfile
+- **After**: AWS S3-compatible access key + secret key
+
+### Mounting
+- **Before**: `gcsfuse --key-file /tmp/gcs-key.json "$GCS_BUCKET_NAME" /gcs`
+- **After**: `tigrisfs "$BUCKET_NAME" /tigris --endpoint="$AWS_ENDPOINT_URL_S3"`
+
+### Environment Variables
+```bash
+# Before (GCS)
+GCS_KEYFILE_JSON="<service-account-json>"
+GCS_BUCKET_NAME="your-gcs-bucket"
+
+# After (Tigris)
+AWS_ACCESS_KEY_ID="tid_xxxxx"
+AWS_SECRET_ACCESS_KEY="tsec_xxxxx"
+BUCKET_NAME="your-tigris-bucket"
+AWS_REGION="auto"
+AWS_ENDPOINT_URL_S3="https://fly.storage.tigris.dev"
+```
+
+## 🚀 Next Steps for Deployment
+
+### For New Deployments
+
+1. **Create Tigris storage**:
+   ```bash
+   fly storage create --name your-email-scheduler-bucket
+   ```
+
+2. **Set secrets**:
+   ```bash
+   flyctl secrets set AWS_ACCESS_KEY_ID="tid_xxxxx"
+   flyctl secrets set AWS_SECRET_ACCESS_KEY="tsec_xxxxx"
+   ```
+
+3. **Update bucket name in `fly.toml`**
+4. **Deploy**: `flyctl deploy`
+
+### For Existing GCS Deployments
+
+1. **Run migration script**:
+   ```bash
+   ./migrate_gcs_to_tigris.sh
+   ```
+
+2. **Follow the script's instructions**
+3. **Deploy updated code**: `flyctl deploy`
+
+## 🎁 Benefits of Tigris
+
+### Cost Benefits
+- **Zero egress fees** (vs. $0.09/GB with GCS)
+- **Predictable pricing** with no surprise bandwidth charges
+- **Free global distribution**
+
+### Performance Benefits
+- **5-10x better performance** for small objects (SQLite pages/WAL segments)
+- **Sub-millisecond latency** for database operations
+- **Strong consistency** (vs. eventual consistency with some providers)
+
+### Operational Benefits
+- **Native Fly.io integration** with optimized routing
+- **No complex IAM setup** - simple access keys
+- **Built on FoundationDB** for enterprise-grade reliability
+
+## 🔍 Verification
+
+After deployment, look for these log messages to confirm successful migration:
+
+```
+🚀 Starting Email Scheduler with Tigris Sync...
+🔐 Setting up Tigris authentication...
+Using endpoint: https://fly.storage.tigris.dev
+Bucket: your-tigris-bucket
+📁 Mounting Tigris bucket: your-tigris-bucket...
+✅ Tigris bucket mounted successfully
+📥 Syncing database from Tigris to local working copy...
+✅ Database synced from Tigris successfully
+```
+
+## 📚 Documentation
+
+- **Primary Guide**: [TIGRIS_DEPLOYMENT.md](./TIGRIS_DEPLOYMENT.md)
+- **Legacy Reference**: [PRODUCTION_DEPLOYMENT.md](./PRODUCTION_DEPLOYMENT.md) (deprecated)
+- **Migration Tool**: [migrate_gcs_to_tigris.sh](./migrate_gcs_to_tigris.sh)
+
+## ⚠️ Important Notes
+
+1. **TigrisFS Performance**: Optimized for SQLite workloads with better small-file performance
+2. **Fly.io Optimization**: Uses `https://fly.storage.tigris.dev` endpoint for best performance on Fly.io
+3. **Credentials Security**: Store credentials as Fly.io secrets, never commit to code
+4. **Global Distribution**: Tigris automatically distributes data globally for low-latency access
+
+## 🆘 Support
+
+If you encounter issues:
+1. Check the troubleshooting section in [TIGRIS_DEPLOYMENT.md](./TIGRIS_DEPLOYMENT.md)
+2. Verify credentials are set correctly as Fly.io secrets
+3. Ensure bucket name matches in `fly.toml`
+4. Check Fly.io logs with `flyctl logs`
+
+The migration maintains the same architecture (sqlite3_rsync + object storage) while providing better performance and cost-effectiveness with Tigris.

--- a/env.example
+++ b/env.example
@@ -1,6 +1,18 @@
-# Turso Database Configuration
+# Tigris Object Storage Configuration
 # Copy this file to .env and fill in your actual values
 
+# Tigris S3-compatible credentials
+AWS_ACCESS_KEY_ID=tid_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+AWS_SECRET_ACCESS_KEY=tsec_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+AWS_REGION=auto
+AWS_ENDPOINT_URL_S3=https://fly.storage.tigris.dev
+BUCKET_NAME=your-tigris-bucket-name
+
+# Application Configuration
+ORG_ID=99
+OCAMLLOG=info
+
+# Turso Database Configuration (if using Turso for primary storage)
 # Your Turso database URL (get with: turso db show --url <database-name>)
 TURSO_DATABASE_URL=libsql://your-database-name-your-org.turso.io
 

--- a/fly.toml
+++ b/fly.toml
@@ -6,9 +6,11 @@ primary_region = "ord"
 
 # Pass environment variables to the container
 [env]
-  GCS_BUCKET_NAME = "your-gcs-bucket-name"
+  BUCKET_NAME = "your-tigris-bucket-name"
   ORG_ID = "99"
   OCAMLLOG = "info"
+  AWS_REGION = "auto"
+  AWS_ENDPOINT_URL_S3 = "https://fly.storage.tigris.dev"
 
 # For one-shot execution (no processes block needed)
 # Python will use `flyctl machine run` to execute
@@ -24,6 +26,6 @@ primary_region = "ord"
   cpu_kind = "performance"
   cpus = 4
 
-# Allow FUSE for gcsfuse mounting
+# Allow FUSE for TigrisFS mounting
 [mounts]
   processes = ["app"] 

--- a/migrate_gcs_to_tigris.sh
+++ b/migrate_gcs_to_tigris.sh
@@ -98,13 +98,18 @@ export AWS_REGION="auto"
 if command -v aws >/dev/null 2>&1; then
     TIGRIS_DB_PATH="s3://$TIGRIS_BUCKET/org-data/$ORG_ID.db"
     
-    # Get credentials from flyctl if possible
-    if AWS_ACCESS_KEY_ID=$(flyctl secrets list 2>/dev/null | grep AWS_ACCESS_KEY_ID | awk '{print $2}' 2>/dev/null); then
-        export AWS_ACCESS_KEY_ID
-    fi
-    
-    if AWS_SECRET_ACCESS_KEY=$(flyctl secrets list 2>/dev/null | grep AWS_SECRET_ACCESS_KEY | awk '{print $2}' 2>/dev/null); then
-        export AWS_SECRET_ACCESS_KEY
+    # Note: flyctl secrets list only shows masked values, not actual credentials
+    # User must configure AWS CLI manually with their Tigris credentials
+    echo "⚠️  Please ensure your AWS CLI is configured with Tigris credentials:"
+    echo "   aws configure set aws_access_key_id 'tid_xxxxx'"
+    echo "   aws configure set aws_secret_access_key 'tsec_xxxxx'"
+    echo "   Or set environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
+    echo ""
+    read -p "Have you configured AWS CLI with your Tigris credentials? (y/N): " AWS_CONFIGURED
+    if [[ ! $AWS_CONFIGURED =~ ^[Yy]$ ]]; then
+        echo "❌ Please configure AWS CLI with Tigris credentials first"
+        echo "   You can find your credentials at: https://fly.io/dashboard/personal/tokens"
+        exit 1
     fi
     
     if aws s3 cp "$LOCAL_DB_PATH" "$TIGRIS_DB_PATH" --endpoint-url "$AWS_ENDPOINT_URL_S3"; then

--- a/migrate_gcs_to_tigris.sh
+++ b/migrate_gcs_to_tigris.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# Migration script from GCS to Tigris
+# This script helps migrate your database from Google Cloud Storage to Tigris
+
+set -e
+
+echo "🔄 Email Scheduler Migration: GCS → Tigris"
+echo "==========================================="
+
+# Check for required tools
+command -v flyctl >/dev/null 2>&1 || { echo "❌ flyctl is required but not installed. Please install it first."; exit 1; }
+command -v gsutil >/dev/null 2>&1 || { echo "❌ gsutil is required but not installed. Please install Google Cloud SDK."; exit 1; }
+
+# Get configuration from user
+echo ""
+echo "📝 Configuration"
+echo "Please provide the following information:"
+
+read -p "GCS bucket name (e.g., your-email-scheduler-bucket): " GCS_BUCKET
+read -p "Tigris bucket name (e.g., your-tigris-bucket): " TIGRIS_BUCKET
+read -p "Organization ID (default: 99): " ORG_ID
+ORG_ID=${ORG_ID:-99}
+
+echo ""
+echo "🔍 Verifying configuration..."
+echo "GCS Bucket: $GCS_BUCKET"
+echo "Tigris Bucket: $TIGRIS_BUCKET"
+echo "Organization ID: $ORG_ID"
+echo ""
+
+read -p "Does this look correct? (y/N): " CONFIRM
+if [[ ! $CONFIRM =~ ^[Yy]$ ]]; then
+    echo "❌ Migration cancelled"
+    exit 1
+fi
+
+# Create backup directory
+BACKUP_DIR="./migration_backup_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$BACKUP_DIR"
+echo "📁 Created backup directory: $BACKUP_DIR"
+
+# Download database from GCS
+echo ""
+echo "📥 Downloading database from GCS..."
+GCS_DB_PATH="gs://$GCS_BUCKET/org-data/$ORG_ID.db"
+LOCAL_DB_PATH="$BACKUP_DIR/database_backup.db"
+
+if gsutil cp "$GCS_DB_PATH" "$LOCAL_DB_PATH"; then
+    echo "✅ Database downloaded successfully"
+    echo "   Local copy: $LOCAL_DB_PATH"
+else
+    echo "❌ Failed to download database from GCS"
+    echo "   Attempted path: $GCS_DB_PATH"
+    echo "   Please verify the bucket name and organization ID"
+    exit 1
+fi
+
+# Verify database integrity
+echo ""
+echo "🔍 Verifying database integrity..."
+if sqlite3 "$LOCAL_DB_PATH" "PRAGMA integrity_check;" | grep -q "ok"; then
+    echo "✅ Database integrity check passed"
+else
+    echo "⚠️  Database integrity check failed - proceeding anyway"
+fi
+
+# Check if Tigris credentials are set
+echo ""
+echo "🔐 Checking Tigris credentials..."
+
+# Try to get secrets from flyctl
+if flyctl secrets list 2>/dev/null | grep -q "AWS_ACCESS_KEY_ID"; then
+    echo "✅ Tigris credentials found in Fly.io secrets"
+else
+    echo "⚠️  Tigris credentials not found in Fly.io secrets"
+    echo ""
+    echo "Please set your Tigris credentials:"
+    echo "flyctl secrets set AWS_ACCESS_KEY_ID='tid_xxxxx'"
+    echo "flyctl secrets set AWS_SECRET_ACCESS_KEY='tsec_xxxxx'"
+    echo ""
+    read -p "Have you set the Tigris credentials? (y/N): " CREDS_SET
+    if [[ ! $CREDS_SET =~ ^[Yy]$ ]]; then
+        echo "❌ Please set Tigris credentials first"
+        exit 1
+    fi
+fi
+
+# Upload database to Tigris
+echo ""
+echo "📤 Uploading database to Tigris..."
+
+# Set Tigris environment variables for AWS CLI compatibility
+export AWS_ENDPOINT_URL_S3="https://fly.storage.tigris.dev"
+export AWS_REGION="auto"
+
+# Check if AWS CLI is available, if not, provide instructions
+if command -v aws >/dev/null 2>&1; then
+    TIGRIS_DB_PATH="s3://$TIGRIS_BUCKET/org-data/$ORG_ID.db"
+    
+    # Get credentials from flyctl if possible
+    if AWS_ACCESS_KEY_ID=$(flyctl secrets list 2>/dev/null | grep AWS_ACCESS_KEY_ID | awk '{print $2}' 2>/dev/null); then
+        export AWS_ACCESS_KEY_ID
+    fi
+    
+    if AWS_SECRET_ACCESS_KEY=$(flyctl secrets list 2>/dev/null | grep AWS_SECRET_ACCESS_KEY | awk '{print $2}' 2>/dev/null); then
+        export AWS_SECRET_ACCESS_KEY
+    fi
+    
+    if aws s3 cp "$LOCAL_DB_PATH" "$TIGRIS_DB_PATH" --endpoint-url "$AWS_ENDPOINT_URL_S3"; then
+        echo "✅ Database uploaded to Tigris successfully"
+        echo "   Tigris path: $TIGRIS_DB_PATH"
+    else
+        echo "❌ Failed to upload database to Tigris"
+        echo "   Please check your Tigris credentials and bucket name"
+        exit 1
+    fi
+else
+    echo "⚠️  AWS CLI not found. Please upload manually:"
+    echo "   1. Install AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html"
+    echo "   2. Configure with your Tigris credentials"
+    echo "   3. Upload with: aws s3 cp $LOCAL_DB_PATH s3://$TIGRIS_BUCKET/org-data/$ORG_ID.db --endpoint-url $AWS_ENDPOINT_URL_S3"
+fi
+
+# Update fly.toml
+echo ""
+echo "📝 Updating fly.toml configuration..."
+
+if [ -f "fly.toml" ]; then
+    # Backup original fly.toml
+    cp fly.toml "$BACKUP_DIR/fly.toml.backup"
+    echo "✅ Backed up original fly.toml"
+    
+    # Update bucket name in fly.toml
+    if sed -i.tmp "s/GCS_BUCKET_NAME = .*/BUCKET_NAME = \"$TIGRIS_BUCKET\"/" fly.toml && rm fly.toml.tmp; then
+        # Add Tigris-specific environment variables if not present
+        if ! grep -q "AWS_ENDPOINT_URL_S3" fly.toml; then
+            echo "  AWS_REGION = \"auto\"" >> fly.toml
+            echo "  AWS_ENDPOINT_URL_S3 = \"https://fly.storage.tigris.dev\"" >> fly.toml
+        fi
+        echo "✅ Updated fly.toml configuration"
+    else
+        echo "⚠️  Could not automatically update fly.toml"
+        echo "   Please manually update BUCKET_NAME in fly.toml"
+    fi
+else
+    echo "⚠️  fly.toml not found in current directory"
+fi
+
+# Deployment instructions
+echo ""
+echo "🚀 Next Steps"
+echo "============="
+echo ""
+echo "1. Review the updated configuration:"
+echo "   - Check fly.toml for correct BUCKET_NAME"
+echo "   - Verify Tigris credentials are set as secrets"
+echo ""
+echo "2. Deploy the updated application:"
+echo "   flyctl deploy"
+echo ""
+echo "3. Test the deployment:"
+echo "   flyctl logs"
+echo ""
+echo "4. Verify successful operation:"
+echo "   Look for: '✅ Database synced from Tigris successfully'"
+echo ""
+echo "📁 Backup Location: $BACKUP_DIR"
+echo "   - Original database: $LOCAL_DB_PATH"
+echo "   - Original fly.toml: $BACKUP_DIR/fly.toml.backup"
+echo ""
+echo "🎉 Migration preparation complete!"
+echo ""
+echo "ℹ️  For detailed deployment instructions, see: TIGRIS_DEPLOYMENT.md"

--- a/migrate_gcs_to_tigris.sh
+++ b/migrate_gcs_to_tigris.sh
@@ -131,13 +131,22 @@ if [ -f "fly.toml" ]; then
     cp fly.toml "$BACKUP_DIR/fly.toml.backup"
     echo "✅ Backed up original fly.toml"
     
-    # Update bucket name in fly.toml
-    if sed -i.tmp "s/GCS_BUCKET_NAME = .*/BUCKET_NAME = \"$TIGRIS_BUCKET\"/" fly.toml && rm fly.toml.tmp; then
+    # Update bucket name in fly.toml (cross-platform compatible)
+    if cp fly.toml fly.toml.tmp && \
+       sed "s/GCS_BUCKET_NAME = .*/BUCKET_NAME = \"$TIGRIS_BUCKET\"/" fly.toml.tmp > fly.toml && \
+       rm fly.toml.tmp; then
+        
         # Add Tigris-specific environment variables if not present
-        if ! grep -q "AWS_ENDPOINT_URL_S3" fly.toml; then
+        # Check and add AWS_REGION if missing
+        if ! grep -q "AWS_REGION" fly.toml; then
             echo "  AWS_REGION = \"auto\"" >> fly.toml
+        fi
+        
+        # Check and add AWS_ENDPOINT_URL_S3 if missing
+        if ! grep -q "AWS_ENDPOINT_URL_S3" fly.toml; then
             echo "  AWS_ENDPOINT_URL_S3 = \"https://fly.storage.tigris.dev\"" >> fly.toml
         fi
+        
         echo "✅ Updated fly.toml configuration"
     else
         echo "⚠️  Could not automatically update fly.toml"


### PR DESCRIPTION
The codebase was pivoted from Google Cloud Storage (GCS) to Tigris object storage for SQLite replication and backup workflows, leveraging Tigris's S3 compatibility and optimizations.

Key modifications include:

*   **`Dockerfile`**: `gcsfuse` installation was replaced with `tigrisfs`, an optimized FUSE driver for Tigris. The mount point was updated from `/gcs` to `/tigris`.
*   **`entrypoint.sh`**: The script was updated to use Tigris S3-compatible environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `BUCKET_NAME`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION`) instead of GCP-specific ones. The mount command was changed from `gcsfuse` to `tigrisfs`, and all GCS-related paths and messages were updated to reflect Tigris.
*   **`fly.toml`**: The `GCS_BUCKET_NAME` variable was replaced with `BUCKET_NAME`, and Tigris-specific endpoint and region variables were added.
*   **`env.example`**: Updated to include Tigris S3-compatible credential examples.
*   **`PRODUCTION_DEPLOYMENT.md`**: Marked as deprecated, with migration instructions and a redirect to the new Tigris deployment guide.
*   **New Files**:
    *   `TIGRIS_DEPLOYMENT.md`: A comprehensive guide for deploying with Tigris.
    *   `migrate_gcs_to_tigris.sh`: An automated script to assist with migrating existing databases from GCS to Tigris.
    *   `TIGRIS_MIGRATION_SUMMARY.md`: A detailed summary of all changes.

The pivot was driven by Tigris's zero egress fees, superior small object performance for Litestream WAL segments, optimized filesystem operations via `tigrisfs`, and strong consistency guarantees. The core `sqlite3_rsync` and FUSE-based architecture remains, now backed by Tigris.